### PR TITLE
Add note to update avalon-setup submodules to Install guide

### DIFF
--- a/pages/2.0/guides.md
+++ b/pages/2.0/guides.md
@@ -149,6 +149,31 @@ git clone https://github.com/getavalon/setup avalon-setup --recursive
 ```
 </div>
 
+Then we need to make sure we pull in the latest updates:
+
+<div class="tabs">
+  <button class="tab cmd" onclick="setTab(event, 'cmd')">
+  	<p>cmd</p><div class="tab-gap"></div>
+  </button>
+  <button class="tab bash " onclick="setTab(event, 'bash')">
+  	<p>bash</p><div class="tab-gap"></div>
+  </button>
+</div>
+
+<div class="tab-content cmd" markdown="1">
+```bat
+cd avalon-setup
+git submodule update --recursive --remote
+```
+</div>
+
+<div class="tab-content bash" markdown="1">
+```bash
+cd avalon-setup
+git submodule update --recursive --remote
+```
+</div>
+
 #### Command-line Interface
 
 Avalon offers a command-line interface through which every interaction takes place.


### PR DESCRIPTION
Add install note to update the `avalon-setup` submodules using:
```
git submodule update --recursive --remote
```

This makes sure that newcomers use the latest codebase of Avalon. The newer versions have a lot of fixes, including compatibility with newer PyQt5 versions. As such this makes sure that less newcomers run into errors with PyQt5. For example, when installing with Python 3.7 then PyQt5 5.7.1 is not available, so new users would often do `pip install PyQt5` instead getting an incompatible PyQt5 for the avalon setup they pulled.

Reference:
- https://gitter.im/getavalon/Lobby?at=5decf8816a85195b9e1d23f5